### PR TITLE
Fix header image and pagename positioning

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -397,7 +397,8 @@
 
 #header-img-a ~ .pagename {
   position: relative;
-  top: -0.25em; }
+  top: -0.25em;
+  display: inline-block; }
 
 .pagename {
   margin: 0;

--- a/style/modules/header/_header-bottom-left.scss
+++ b/style/modules/header/_header-bottom-left.scss
@@ -62,6 +62,7 @@
 #header-img-a ~ .pagename {
   position: relative;
   top: em(-4, 16);
+  display: inline-block;
 }
 
 // subreddit name


### PR DESCRIPTION
Repositions header and pagename when custom header image is used

<img width="423" alt="dkb1qsl" src="https://cloud.githubusercontent.com/assets/8265238/8564763/0bf2e638-2504-11e5-9e5c-78bc7a337703.png">
